### PR TITLE
Remove defprotocol+, fix reloading deftype+ behavior

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject potemkin "0.4.8"
+(defproject griffinbank/potemkin "0.4.9-20250811"
   :license {:name "MIT License"}
   :description "Some useful facades."
   :deploy-repositories [["clojars" {:url "https://repo.clojars.org"


### PR DESCRIPTION
Remove defprotocol+, remove the part of deftype+ that behaves the same as defprotocol+. Retain deftype+'s ability to define abstract classes. 

These changes help avoid AOT issues with rules_clojure. Upgrading potemkin requires bumping both byte-streams and manifold. 